### PR TITLE
Soporte multilenguaje (español/inglés)

### DIFF
--- a/blog/2025-10-25-alpa-corral.md
+++ b/blog/2025-10-25-alpa-corral.md
@@ -10,7 +10,7 @@ tags: [bitacora]
 El sábado pasado viajamos a **Alpa Corral**, en el sur de Córdoba, invitados por el equipo de la **Universidad Nacional de Río Negro**, liderado por **Daniel Belomo**, y la **Asociación Civil Tierra Unida Activa**, que impulsan un proyecto de **red comunitaria comunitaria y científica Las Lagunitas Alpa Corral**.
 El objetivo de la jornada era compartir experiencias sobre herramientas libres para la gestión del territorio y la comunicación en zonas rurales, con especial foco en el **combate de incendios forestales**.
 
-<!-- truncate -->
+{/* truncate */}
 
 ## El viaje y la llegada
 

--- a/blog/2025-11-20-primer-borrador-de-compra.md
+++ b/blog/2025-11-20-primer-borrador-de-compra.md
@@ -16,7 +16,7 @@ Durante las primeras semanas de trabajo investigamos las opciones disponibles en
 
 En este proceso fueron apareciendo muchas preguntas —que iremos compartiendo a lo largo del proyecto—, pero hoy queremos enfocarnos en mostrarles los dispositivos que consideramos más adecuados para esta primera tanda de compra.
 
-<!-- truncate -->
+{/* truncate */}
 
 Buscamos exclusivamente dispositivos de usuario final: aquellos que no requieren ensamblaje y vienen listos para usar. Los evaluamos en función de lo que entendemos preliminarmente como los requerimientos del combate del fuego:
 

--- a/blog/compras-12-25.md
+++ b/blog/compras-12-25.md
@@ -41,7 +41,6 @@ Si bien existe una gran cantidad de dispositivos en el mercado, luego de un aná
 
 :::warning ADVERTENCIA:
 Nuestra elección de dispositivos y cantidades están dirigidas a los combatientes del fuego, a las situaciones que deben afrontar y a nuestras creencias sobre las necesidades que deben estar cubiertas.
-<!-- Este proceso de elección seguramente cambiará una vez realizada las pruebas de campo con los bomberos. Y en una eventual compra futura, aquí se adjuntará su respectivo blog. -->
 :::
 
 Si hablamos de los dispositivos **portables**, adquirimos 6 de c/u (N37 y M1) y 6 MeshPocket. Aunque estos últimos son powerbanks (de 10.000mAh en el modelo elegido), también pueden desempeñarse como los dos anteriores. Es de nuestro intrés saber cómo trabajan estos dispositivos en entornos donde los dispositivos son homogéneos, para luego evaluarlos en escenarios mixtos, y contrastar los resultados obtenidos, ya que este último posiblemente se aproxime más a la realidad.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -33,7 +33,19 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'es',
-    locales: ['es'],
+    locales: ['es', 'en'],
+    localeConfigs: {
+      es: {
+        label: 'Español',
+        direction: 'ltr',
+        htmlLang: 'es',
+      },
+      en: {
+        label: 'English',
+        direction: 'ltr',
+        htmlLang: 'en',
+      },
+    },
   },
 
   presets: [
@@ -90,6 +102,10 @@ const config: Config = {
         {
           href: 'https://github.com/Wildfire-Mesh/Documentacion',
           label: 'GitHub',
+          position: 'right',
+        },
+        {
+          type: 'localeDropdown',
           position: 'right',
         },
       ],

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -1,0 +1,333 @@
+{
+  "homepage.tagline": {
+    "message": "All connected fighting fire",
+    "description": "Homepage hero tagline"
+  },
+  "homepage.button": {
+    "message": "Learn more... 👨🏼‍🚒",
+    "description": "Homepage hero button label"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View all tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 item|{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Edit this page",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "warning",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expand sidebar category '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Collapse sidebar category '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read more",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Authors",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "View all authors",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "This author has not written any posts yet.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Unlisted page",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "This page is unlisted. Search engines will not index it, and only users having a direct link can access it.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Draft page",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "This page is a draft. It will only be visible in dev and be excluded from the production build.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-blog/options.json
+++ b/i18n/en/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Recent posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,6 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  }
+}

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+---
+
+
+# Meshtastic for Wildfire Fighting in Argentina
+
+## About Our Project
+
+We are **WildfireMesh**, a collective that integrates the principles of Free Software and the Decentralized Web. Our goal is to strengthen communications for firefighters in Argentina during wildfires, where current methods are insufficient and often fail. We focus on the adoption of **[Meshtastic](https://meshtastic.org/)**, a long-range off-grid communication platform that uses LoRa radios and is 100% open source and community-managed.
+
+Our mission is to **facilitate the adoption of these technologies**. We plan to do so by providing easy-to-acquire kits, targeted training, technical support, and relevant documentation. We firmly believe that fire brigades and emergency teams will benefit from an accessible mesh network technology that can connect and save lives during natural disasters. We aspire for Meshtastic to become a complementary standard for digital communications, useful as a contingency channel when primary systems fail.
+
+All content generated throughout the project, including documentation (manuals, guides, use cases) and software, will be **open source**. We are committed to building an active community around this open source content and software, spreading this culture of collaboration and open access to information. We plan to publish everything on a dedicated website, sharing progress, results, testimonials, and documentation of activities.
+
+## Blog
+
+Throughout this project we will be publishing content on this site, but for now we have the experiences that our team members have shared on different platforms. Here are some examples:
+
+*   **["A visit to rural Tanzania"](https://nico.today/a-visit-to-rural-tanzania/)**: An article documenting our exploration of the minimum telecommunications infrastructure needed for remote rural communities, inspiring deployable and self-sufficient solutions.
+*   **["Tracking boats with Meshtastic"](https://nico.today/tracking-canoes-with-meshtastic/)**: Documentation of a hands-on experience where we applied Meshtastic devices for tracking boat patrols in the Amazon, highlighting the potential of this technology for specific needs. This project also underscores the importance of documenting how to reproduce solutions and create user documentation.
+*   Coming soon, we will publish more relevant content about our experiences in "Myanmar" and with "Sudoroom and Disaster Radio" in Oakland.
+
+You can explore these and other contents at [nico.today](https://nico.today).
+
+## ATAK and CRDT Ideas
+
+We are actively researching and developing the integration of various tools to optimize firefighting operations, recognizing their specific needs in the field:
+
+*   **ATAK (Android Team Awareness Kit)**: We have conducted **workshops and field exercises with fire brigades**, such as the **Chiviquín Brigade in Unquillo, Córdoba**, where we tested Meshtastic and ATAK together. The experience was very positive, and the brigades expressed clear interest in continuing this conversation to integrate these tools into their operations. ATAK is crucial for situational awareness and real-time coordination.
+*   **CRDT (Conflict-Free Replicated Data Types)**: Our project aims to make Meshtastic, already robust for off-grid communication, directly adapted to the demanding operational needs of emergency teams in high-risk situations. This includes the ability to share vital information such as location, instructions, and situational awareness during missions, in a resilient manner against communication failures. The exploration of CRDTs is key to handling data robustly in unstable environments.
+
+## Contacts with Organizations
+
+Our work is grounded in **direct collaboration and deep roots in firefighting communities**. We have established strong relationships with volunteer fire brigades in Argentina, who have been fundamental in validating our hypotheses and showing great interest in our solutions:
+
+*   We have been in **direct and ongoing contact** with brigades in several Argentine provinces, including **Sierra de los Padres and Coronel Dorrego (Buenos Aires), Unquillo (Córdoba), and El Bolsón (Río Negro)**.
+*   These brigades have not only **[validated the urgent need](https://nico.today/exploring-the-integration-of-meshtastic-and-atak-in-firefighting-communications-a-practice-with-chiviquin-brigade/)** for better communication solutions, but have also **expressed great interest in Meshtastic** as a complementary tool for their operations.
+*   The **willingness of fighters to test equipment and develop joint methodologies** has already been validated, as in the workshop with the Chiviquín Brigade, where their response was "clear: let's continue this conversation". This interaction demonstrates our ability to collaborate directly with beneficiary communities.
+*   We have **supporting documentation** from these brigades, such as executive summaries and endorsement letters, validating the importance of our proposal from the perspective of those on the front lines of firefighting.

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,0 +1,26 @@
+{
+  "link.title.-": {
+    "message": "-",
+    "description": "The title of the footer links column with title=- in the footer"
+  },
+  "link.title.Social": {
+    "message": "Social",
+    "description": "The title of the footer links column with title=Social in the footer"
+  },
+  "link.title.More": {
+    "message": "More",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/Wildfire-Mesh/Documentacion"
+  },
+  "copyright": {
+    "message": "Copyright © 2026 My Project, Inc. Built with Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "message": "Wildfire-Mesh",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "WildfireMesh Logo",
+    "description": "WildfireMesh Logo"
+  },
+  "item.label.Proyecto": {
+    "message": "Project",
+    "description": "Navbar item with label Proyecto"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.8.1",
-    "@docusaurus/preset-classic": "3.8.1",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/faster": "^3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -24,9 +25,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.8.1",
-    "@docusaurus/tsconfig": "3.8.1",
-    "@docusaurus/types": "3.8.1",
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/tsconfig": "3.10.1",
+    "@docusaurus/types": "3.10.1",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,23 +5,32 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
+import {translate} from '@docusaurus/Translate';
 
 import styles from './index.module.css';
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
+  const tagline = translate({
+    id: 'homepage.tagline',
+    message: 'Todos conectados combatiendo el fuego',
+  });
+  const buttonLabel = translate({
+    id: 'homepage.button',
+    message: 'Quiero saber más... 👨🏼‍🚒',
+  });
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className="hero__subtitle">{tagline}</p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Quiero saber más... 👨🏼‍🚒
+            {buttonLabel}
           </Link>
         </div>
       </div>


### PR DESCRIPTION
Se configuró Docusaurus para soportar dos idiomas (español por defecto, inglés opcional) con selector de idioma en la navbar. Se tradujo al inglés la homepage y la página de introducción. Como parte del proceso, se actualizó Docusaurus de 3.8.1 a 3.10.1 y se corrigió la sintaxis de comentarios en los posts del blog para compatibilidad con MDX 3. 

Closes #11 